### PR TITLE
Update semver regex handling

### DIFF
--- a/bdast.yaml
+++ b/bdast.yaml
@@ -94,7 +94,7 @@ steps:
         "X-GitHub-Api-Version": "2022-11-28"
       body: |
         {
-          "tag_name": "{{ version.original }}",
+          "tag_name": "{{ version.post_discard }}",
           "name": "Version {{ version.full }}",
           "draft": false,
           "prerelease": {{ 'true' if version.is_prerelease else 'false' }},


### PR DESCRIPTION
Fix url header type check
Fix url body post
Split strip regex in to discard and ignore fields for discarding
components of the version and ignoring parts of the version
- Ignored components reappear in 'original'
- Both can be accessed via their namesake properties, post_discard and
  post_ignore
Added the original unmodified source to the output var
